### PR TITLE
Improved RLlib training & rollouts

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -38,6 +38,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    env:
+      PYTHONHASHSEED: 1
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8

--- a/examples/environments/digital_ads_market/digital_ads_market.py
+++ b/examples/environments/digital_ads_market/digital_ads_market.py
@@ -781,7 +781,6 @@ if __name__ == "__main__":
         results = ph.utils.rllib.rollout(
             directory=path,
             num_repeats=50,
-            num_workers=40,
             metrics=metrics,
             record_messages=False,
             env_config={
@@ -885,16 +884,11 @@ if __name__ == "__main__":
                     "sport": NUM_SPORT_ADVERTISERS,
                 },
             },
+            iterations=1e4,
+            checkpoint_freq=50,
             rllib_config={
                 "seed": 0,
                 "batch_mode": "complete_episodes",
                 "disable_env_checking": True,
-            },
-            tune_config={
-                "name": "simple",
-                "checkpoint_freq": 50,
-                "stop": {
-                    "training_iteration": 1e4,
-                },
             },
         )

--- a/examples/environments/simple_market/market_agents.py
+++ b/examples/environments/simple_market/market_agents.py
@@ -8,6 +8,7 @@ from gym.spaces import Box, Discrete
 # Message Payloads
 ##############################################################
 
+
 # Could extend to include price + vol / price curve
 @dataclass(frozen=True)
 class Price(ph.MsgPayload):
@@ -21,6 +22,7 @@ class Order(ph.MsgPayload):
 
 # Buyer Agent
 ###############################################################
+
 
 # Buyer type = buyer's intrinsic value for the good
 @dataclass

--- a/examples/environments/supply_chain/supply_chain.py
+++ b/examples/environments/supply_chain/supply_chain.py
@@ -196,22 +196,18 @@ if sys.argv[1] == "train":
         algorithm="PPO",
         env_class=SupplyChainEnv,
         env_config={},
+        iterations=500,
+        checkpoint_freq=50,
         policies={"shop_policy": ["SHOP"]},
         metrics=metrics,
-        rllib_config={"seed": 0},
-        tune_config={
-            "name": "supply_chain",
-            "checkpoint_freq": 100,
-            "stop": {
-                "training_iteration": 300,
-            },
-        },
+        results_dir="~/ray_results/supply_chain",
     )
 
 elif sys.argv[1] == "rollout":
     results = ph.utils.rllib.rollout(
-        directory="supply_chain/LATEST",
+        directory="~/ray_results/supply_chain/LATEST",
         num_repeats=100,
+        num_workers=1,
         metrics=metrics,
     )
 

--- a/examples/trainers/ppo/distributions.py
+++ b/examples/trainers/ppo/distributions.py
@@ -11,6 +11,7 @@ Modify standard PyTorch distributions so they are compatible with this code.
 # Standardize distribution interfaces
 #
 
+
 # Categorical
 class FixedCategorical(torch.distributions.Categorical):
     def sample(self):

--- a/examples/trainers/ppo/trainer.py
+++ b/examples/trainers/ppo/trainer.py
@@ -2,8 +2,8 @@ from collections import defaultdict
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Type
 
 import numpy as np
+import rich.progress
 import torch
-from tqdm import trange
 
 from ...env import PhantomEnv
 from ...logging import Metric
@@ -148,7 +148,7 @@ class PPOTrainer(Trainer):
 
         # episode_rewards = deque(maxlen=10)
 
-        for i in trange(num_iterations):
+        for i in rich.progress.track(range(num_iterations), description="Training..."):
             if self.use_linear_lr_decay:
                 # decrease learning rate linearly
                 update_linear_schedule(self.optimizer, i, num_iterations, self.lr)

--- a/phantom/env.py
+++ b/phantom/env.py
@@ -98,8 +98,9 @@ class PhantomEnv:
             for agent_id, agent_supertype in agent_supertypes.items():
                 if isinstance(agent_supertype, dict):
                     agent_supertype = self.agents[agent_id].Supertype(**agent_supertype)
-                else:
-                    assert isinstance(agent_supertype, self.agents[agent_id].Supertype)
+                # TODO: fix, temporarily disabled as AgentClass.Supertype changed to __main__.Supertype
+                # else:
+                #     assert isinstance(agent_supertype, self.agents[agent_id].Supertype)
 
                 # The env will manage sampling the supertype values
                 agent_supertype._managed = True

--- a/phantom/metrics.py
+++ b/phantom/metrics.py
@@ -296,7 +296,7 @@ def logging_helper(
     metrics: Dict[str, Metric],
     metric_values: DefaultDict[str, List[float]],
 ) -> None:
-    for (metric_id, metric) in metrics.items():
+    for metric_id, metric in metrics.items():
         if (
             not isinstance(env, FiniteStateMachineEnv)
             or metric.fsm_stages is None

--- a/phantom/trainer.py
+++ b/phantom/trainer.py
@@ -19,8 +19,8 @@ from typing import (
 
 import gym
 import numpy as np
+import rich.progress
 import tensorboardX as tbx
-from tqdm import trange
 
 from .types import AgentID, PolicyID
 from .agents import Agent
@@ -186,7 +186,7 @@ class Trainer(ABC):
                     f"Policy ID '{policy_to_train}' in 'policies_to_train' must be of trainer policy type '{self.policy_class.__name__}'"
                 )
 
-        for i in trange(num_iterations):
+        for i in rich.progress.track(range(num_iterations), description="Training..."):
             self.training_step(env, policy_mapping, policy_instances, policies_to_train)
             self.tbx_write_values(i)
 

--- a/phantom/utils/ranges.py
+++ b/phantom/utils/ranges.py
@@ -46,15 +46,17 @@ class UniformRange(Range[float]):
         end: float,
         step: float = 1.0,
         name: Optional[str] = None,
+        dtype=None,
     ) -> None:
         self.start = start
         self.end = end
         self.step = step
+        self.dtype = dtype
 
         super().__init__(name)
 
     def values(self) -> np.ndarray:
-        return np.arange(self.start, self.end, self.step)
+        return np.arange(self.start, self.end, self.step, dtype=self.dtype)
 
 
 class LinspaceRange(Range[float]):
@@ -69,15 +71,17 @@ class LinspaceRange(Range[float]):
         end: float,
         n: int,
         name: Optional[str] = None,
+        dtype=None,
     ) -> None:
         self.n = n
         self.start = start
         self.end = end
+        self.dtype = dtype
 
         super().__init__(name)
 
     def values(self) -> np.ndarray:
-        return np.linspace(self.start, self.end, self.n)
+        return np.linspace(self.start, self.end, self.n, dtype=self.dtype)
 
 
 class UnitArrayUniformRange(UniformRange, Range[np.ndarray]):
@@ -90,7 +94,10 @@ class UnitArrayUniformRange(UniformRange, Range[np.ndarray]):
     """
 
     def values(self) -> List[np.ndarray]:
-        return [np.array([x]) for x in np.arange(self.start, self.end, self.step)]
+        return [
+            np.array([x])
+            for x in np.arange(self.start, self.end, self.step, dtype=self.dtype)
+        ]
 
 
 class UnitArrayLinspaceRange(LinspaceRange, Range[np.ndarray]):
@@ -103,4 +110,7 @@ class UnitArrayLinspaceRange(LinspaceRange, Range[np.ndarray]):
     """
 
     def values(self) -> List[np.ndarray]:
-        return [np.array([x]) for x in np.linspace(self.start, self.end, self.n)]
+        return [
+            np.array([x])
+            for x in np.linspace(self.start, self.end, self.n, dtype=self.dtype)
+        ]

--- a/phantom/utils/rllib/__init__.py
+++ b/phantom/utils/rllib/__init__.py
@@ -23,7 +23,7 @@ def find_most_recent_results_dir(base_path: Union[Path, str]) -> Path:
         # Not all directories will be experiment results directories. Filter by
         # attempting to parse a datetime from the directory name.
         try:
-            datetime.strptime(str(directory)[-19:], "%Y-%m-%d_%H-%M-%S")
+            datetime.strptime(str(directory)[-27:-8], "%Y-%m-%d_%H-%M-%S")
             experiment_directories.append(directory)
         except ValueError:
             pass
@@ -32,7 +32,7 @@ def find_most_recent_results_dir(base_path: Union[Path, str]) -> Path:
         raise ValueError(f"No experiment directories found in '{base_path}'")
 
     experiment_directories.sort(
-        key=lambda d: datetime.strptime(str(d)[-19:], "%Y-%m-%d_%H-%M-%S")
+        key=lambda d: datetime.strptime(str(d)[-27:-8], "%Y-%m-%d_%H-%M-%S")
     )
 
     return experiment_directories[-1]

--- a/phantom/utils/rllib/policy_evaluation.py
+++ b/phantom/utils/rllib/policy_evaluation.py
@@ -20,6 +20,7 @@ def evaluate_policy(
     directory: Union[str, Path],
     policy_id: str,
     obs: Any,
+    explore: bool,
     batch_size: int = 100,
     checkpoint: Optional[int] = None,
     show_progress_bar: bool = True,
@@ -38,6 +39,7 @@ def evaluate_policy(
             :class:`Range` class instances to evaluate the policy over multiple
             dimensions in a similar fashion to the :func:`ph.utils.rllib.rollout`
             function.
+        explore: Parameter passed to the policy.
         batch_size: Number of observations to evaluate at a time.
         checkpoint: Checkpoint to use (defaults to most recent).
         show_progress_bar: If True shows a progress bar in the terminal output.
@@ -98,7 +100,7 @@ def evaluate_policy(
 
         processed_obs = [preprocessor.transform(ob) for ob in obs]
 
-        squashed_actions = policy.compute_actions(processed_obs, explore=False)[0]
+        squashed_actions = policy.compute_actions(processed_obs, explore=explore)[0]
 
         actions = [
             unsquash_action(action, policy.action_space_struct)

--- a/phantom/utils/rllib/policy_evaluation.py
+++ b/phantom/utils/rllib/policy_evaluation.py
@@ -92,7 +92,7 @@ def evaluate_policy(
         variations = variations2
 
     if show_progress_bar:
-        variations = rich.progress.track(range(variations))
+        variations = rich.progress.track(variations)
 
     return [
         (params, algo.compute_single_action(obs, policy_id=policy_id, explore=False))

--- a/phantom/utils/rllib/policy_evaluation.py
+++ b/phantom/utils/rllib/policy_evaluation.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import cloudpickle
 import ray
+import rich.progress
 from ray.tune.registry import register_env
-from tqdm import tqdm
 
 from .. import (
     collect_instances_of_type_with_paths,
@@ -92,7 +92,7 @@ def evaluate_policy(
         variations = variations2
 
     if show_progress_bar:
-        variations = tqdm(variations)
+        variations = rich.progress.track(range(variations))
 
     return [
         (params, algo.compute_single_action(obs, policy_id=policy_id, explore=False))

--- a/phantom/utils/rllib/rollout.py
+++ b/phantom/utils/rllib/rollout.py
@@ -59,6 +59,7 @@ def rollout(
     metrics: Optional[Mapping[str, Metric]] = None,
     record_messages: bool = False,
     show_progress_bar: bool = True,
+    vectorized_env_batch_size: int = 1,
 ) -> Generator[Rollout, None, None]:
     """Performs rollouts for a previously trained Phantom experiment.
 
@@ -89,6 +90,7 @@ def rollout(
         record_messages: If True the full list of episode messages for each of the
             rollouts will be recorded. Only applies if `save_trajectories` is also True.
         show_progress_bar: If True shows a progress bar in the terminal output.
+        vectorized_env_batch_size: TODO
 
     Returns:
         A Generator of Rollouts.
@@ -100,6 +102,11 @@ def rollout(
         reproducibility issues.
     """
     assert num_repeats > 0, "num_repeats must be at least 1"
+
+    assert vectorized_env_batch_size > 0, "vectorized_env_batch_size must be at least 1"
+
+    if vectorized_env_batch_size > 1 and issubclass(env_class, FiniteStateMachineEnv):
+        raise ValueError("Cannot use FSM env when vectorized_env_batch_size > 1")
 
     if num_workers is not None:
         assert num_workers >= 0, "num_workers must be at least 0"
@@ -192,6 +199,7 @@ def rollout(
             rollout_configs,
             env_class,
             custom_policy_mapping,
+            vectorized_env_batch_size,
             metrics,
             record_messages,
         )
@@ -221,6 +229,7 @@ def rollout(
                 rollout_configs[i : i + rollouts_per_worker],
                 env_class,
                 custom_policy_mapping,
+                vectorized_env_batch_size,
                 metrics,
                 record_messages,
             )
@@ -242,103 +251,127 @@ def rollout(
 def _rollout_task_fn(
     policy_mapping_fn: Callable[[], str],
     checkpoint_path: Path,
-    configs: List["_RolloutConfig"],
+    all_configs: List["_RolloutConfig"],
     env_class: Type[PhantomEnv],
     custom_policy_mapping: CustomPolicyMapping,
-    tracked_metrics: Optional[Mapping[str, Metric]] = None,
+    vectorized_env_batch_size: int,
+    metric_objects: Optional[Mapping[str, Metric]] = None,
     record_messages: bool = False,
 ) -> Generator[Rollout, None, None]:
     """Internal function"""
+
+    def chunker(seq, size):
+        return (seq[pos : pos + size] for pos in range(0, len(seq), size))
+
     # Lazily load checkpointed policy objects
     saved_policies: Dict[str, RLlibPolicy] = {}
 
-    for rollout_config in configs:
-        # Create environment instance from config from results directory
-        env = env_class(**rollout_config.env_config)
+    # Setting seed needs to come after algo setup
+    np.random.seed(all_configs[0].rollout_id)
+
+    for configs in chunker(all_configs, vectorized_env_batch_size):
+        batch_size = len(configs)
+
+        vec_envs = [
+            env_class(**rollout_config.env_config) for rollout_config in configs
+        ]
 
         if record_messages:
-            env.network.resolver.enable_tracking = True
+            for env in vec_envs:
+                env.network.resolver.enable_tracking = True
 
-        # Setting seed needs to come after algo setup
-        np.random.seed(rollout_config.rollout_id)
+        vec_metrics = [defaultdict(list) for _ in range(batch_size)]
+        vec_all_steps = [[] for _ in range(batch_size)]
 
-        metrics: DefaultDict[str, List[float]] = defaultdict(list)
-
-        steps: List[Step] = []
-
-        observation = env.reset()
+        vec_observations = [env.reset() for env in vec_envs]
 
         initted_policy_mapping = {
             agent_id: policy(
-                env[agent_id].observation_space, env[agent_id].action_space
+                vec_envs[0][agent_id].observation_space,
+                vec_envs[0][agent_id].action_space,
             )
             for agent_id, policy in custom_policy_mapping.items()
         }
 
         # Run rollout steps.
-        for i in range(env.num_steps):
-            step_actions = {}
+        for i in range(vec_envs[0].num_steps):
+            actions = {}
 
-            for agent_id, agent_obs in observation.items():
+            dict_observations = {
+                k: [dic[k] for dic in vec_observations] for k in vec_observations[0]
+            }
+
+            for agent_id, vec_agent_obs in dict_observations.items():
                 if agent_id in initted_policy_mapping:
-                    action = initted_policy_mapping[agent_id].compute_action(agent_obs)
+                    actions[agent_id] = [
+                        initted_policy_mapping[agent_id].compute_action(agent_obs)
+                        for agent_obs in vec_agent_obs
+                    ]
                 else:
-                    policy_id = policy_mapping_fn(
-                        agent_id, rollout_config.rollout_id, 0
-                    )
+                    policy_id = policy_mapping_fn(agent_id, 0, 0)
 
                     if policy_id not in saved_policies:
                         saved_policies[policy_id] = RLlibPolicy.from_checkpoint(
                             checkpoint_path / "policies" / policy_id
                         )
 
-                    action = saved_policies[policy_id].compute_single_action(
-                        agent_obs, explore=False
+                    actions[agent_id] = saved_policies[policy_id].compute_actions(
+                        vec_agent_obs, explore=False
                     )[0]
 
-                step_actions[agent_id] = action
-
-            new_observation, reward, done, info = env.step(step_actions)
-
-            if tracked_metrics is not None:
-                logging_helper(env, tracked_metrics, metrics)
-
-            if record_messages:
-                messages = deepcopy(env.network.resolver.tracked_messages)
-                env.network.resolver.clear_tracked_messages()
+            # hack for no agent acting step in Ops
+            if len(dict_observations) == 0:
+                vec_actions = [{}] * batch_size
             else:
-                messages = None
+                vec_actions = [dict(zip(actions, t)) for t in zip(*actions.values())]
 
-            steps.append(
-                Step(
-                    i,
-                    observation,
-                    reward,
-                    done,
-                    info,
-                    step_actions,
-                    messages,
-                    env.previous_stage
-                    if isinstance(env, FiniteStateMachineEnv)
-                    else None,
+            vec_steps = [
+                env.step(actions) for env, actions in zip(vec_envs, vec_actions)
+            ]
+
+            for j in range(batch_size):
+                if metric_objects is not None:
+                    logging_helper(vec_envs[j], metric_objects, vec_metrics[j])
+
+                if record_messages:
+                    messages = deepcopy(env.network.resolver.tracked_messages)
+                    env.network.resolver.clear_tracked_messages()
+                else:
+                    messages = None
+
+                vec_all_steps[j].append(
+                    Step(
+                        i,
+                        vec_observations[j],
+                        vec_steps[j].rewards,
+                        vec_steps[j].dones,
+                        vec_steps[j].infos,
+                        vec_actions[j],
+                        messages,
+                        vec_envs[j].previous_stage
+                        if isinstance(vec_envs[j], FiniteStateMachineEnv)
+                        else None,
+                    )
                 )
+
+            vec_observations = [step.observations for step in vec_steps]
+
+        for j in range(batch_size):
+            reduced_metrics = {
+                metric_id: metric_objects[metric_id].reduce(
+                    vec_metrics[j][metric_id], "evaluate"
+                )
+                for metric_id in metric_objects
+            }
+
+            yield Rollout(
+                configs[j].rollout_id,
+                configs[j].repeat_id,
+                configs[j].env_config,
+                configs[j].rollout_params,
+                vec_all_steps[j],
+                reduced_metrics,
             )
-
-            observation = new_observation
-
-        reduced_metrics = {
-            metric_id: tracked_metrics[metric_id].reduce(metrics[metric_id], "evaluate")
-            for metric_id in tracked_metrics
-        }
-
-        yield Rollout(
-            rollout_config.rollout_id,
-            rollout_config.repeat_id,
-            rollout_config.env_config,
-            rollout_config.rollout_params,
-            steps,
-            reduced_metrics,
-        )
 
 
 @dataclass(frozen=True)

--- a/phantom/utils/rllib/rollout.py
+++ b/phantom/utils/rllib/rollout.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import (
     Any,
     Callable,
-    DefaultDict,
     Dict,
     Generator,
     List,
@@ -39,7 +38,6 @@ from .. import (
     Range,
     Sampler,
 )
-from .wrapper import RLlibEnvWrapper
 from . import construct_results_paths
 
 
@@ -334,8 +332,8 @@ def _rollout_task_fn(
                     logging_helper(vec_envs[j], metric_objects, vec_metrics[j])
 
                 if record_messages:
-                    messages = deepcopy(env.network.resolver.tracked_messages)
-                    env.network.resolver.clear_tracked_messages()
+                    messages = deepcopy(vec_envs[j].network.resolver.tracked_messages)
+                    vec_envs[j].network.resolver.clear_tracked_messages()
                 else:
                     messages = None
 

--- a/phantom/utils/rllib/train.py
+++ b/phantom/utils/rllib/train.py
@@ -198,11 +198,6 @@ def train(
         "env_config": env_config,
         "framework": "torch",
         "logger_creator": logger_creator,
-        "multiagent": {
-            "policies": policy_specs,
-            "policy_mapping_fn": policy_mapping_fn,
-            "policies_to_train": policies_to_train,
-        },
         "num_sgd_iter": 10,
         "num_rollout_workers": num_workers_,
         "rollout_fragment_length": env.num_steps,
@@ -211,6 +206,13 @@ def train(
     }
 
     config.update(rllib_config)
+
+    config["multiagent"] = {
+        "policies": policy_specs,
+        "policy_mapping_fn": policy_mapping_fn,
+        "policies_to_train": policies_to_train,
+    }
+    config["multiagent"].update(rllib_config.get("multiagent", {}))
 
     if algorithm == "PPO":
         config["sgd_minibatch_size"] = max(int(config["train_batch_size"] / 10), 1)

--- a/phantom/utils/rllib/train.py
+++ b/phantom/utils/rllib/train.py
@@ -209,7 +209,12 @@ def train(
     if algorithm == "PPO":
         config["sgd_minibatch_size"] = max(int(config["train_batch_size"] / 10), 1)
 
-    algo = ALGORITHMS[algorithm]()[0].get_default_config().from_dict(config).build()
+    algo = (
+        ray.tune.registry.get_trainable_cls(algorithm)
+        .get_default_config()
+        .from_dict(config)
+        .build()
+    )
 
     ray.init(ignore_reinit_error=True)
 

--- a/phantom/utils/rllib/train.py
+++ b/phantom/utils/rllib/train.py
@@ -1,5 +1,6 @@
-import logging
 import os
+import tempfile
+from datetime import datetime
 from inspect import isclass
 from pathlib import Path
 from typing import (
@@ -17,24 +18,23 @@ import cloudpickle
 import gym
 import numpy as np
 import ray
+import rich.pretty
+import rich.progress
 from ray import rllib
+from ray.rllib.algorithms import Algorithm
+from ray.rllib.algorithms.registry import ALGORITHMS
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.evaluation import Episode, MultiAgentEpisode
 from ray.rllib.policy.sample_batch import SampleBatch
 from ray.rllib.utils.typing import TensorStructType, TensorType
-from ray.tune.logger import LoggerCallback
 
 from ...agents import Agent
 from ...env import PhantomEnv
-from ...fsm import FiniteStateMachineEnv
 from ...metrics import Metric, logging_helper
 from ...policy import Policy
 from ...types import AgentID
 from .. import check_env_config, show_pythonhashseed_warning
 from .wrapper import RLlibEnvWrapper
-
-
-logger = logging.getLogger(__name__)
 
 
 PolicyClass = Union[Type[Policy], Type[rllib.Policy]]
@@ -56,13 +56,15 @@ def train(
     algorithm: str,
     env_class: Type[PhantomEnv],
     policies: PolicyMapping,
+    iterations: int,
+    checkpoint_freq: Optional[int] = None,
     num_workers: Optional[int] = None,
     env_config: Optional[Mapping[str, Any]] = None,
     rllib_config: Optional[Mapping[str, Any]] = None,
-    tune_config: Optional[Mapping[str, Any]] = None,
     metrics: Optional[Mapping[str, Metric]] = None,
-    local_mode: bool = False,
-):
+    results_dir: str = ray.tune.result.DEFAULT_RESULTS_DIR,
+    show_training_metrics: bool = False,
+) -> Algorithm:
     """Performs training of a Phantom experiment using the RLlib library.
 
     Any objects that inherit from BaseSampler in the env_supertype or agent_supertypes
@@ -74,12 +76,14 @@ def train(
             be provided).
         env_class: A PhantomEnv subclass.
         policies: A mapping of policy IDs to policy configurations.
-        num_workers: Number of Ray workers to initialise (defaults to 'NUM CPU - 1').
+        iterations: Number of training iterations to perform.
+        checkpoint_freq: The iteration frequency to save policy checkpoints at.
+        num_workers: Number of Ray rollout workers to use (defaults to 'NUM CPU - 1').
         env_config: Configuration parameters to pass to the environment init method.
         rllib_config: Optional algorithm parameters dictionary to pass to RLlib.
-        tune_config: Optional algorithm parameters dictionary to pass to Ray Tune.
         metrics: Optional set of metrics to record and log.
-        local_mode: Use RLlib's local mode option for training (default is False).
+        results_dir: A custom results directory, default is ~/ray_results/
+        show_training_metrics: Set to True to print training metrics every iteration.
 
     The ``policies`` parameter defines which agents will use which policy. This is key
     to performing shared policy learning. The function expects a mapping of
@@ -105,7 +109,7 @@ def train(
         The Ray Tune experiment results object.
 
     .. note::
-        It is the users responsibility to invoke rollouts via the provided ``phantom``
+        It is the users responsibility to invoke training via the provided ``phantom``
         command or ensure the ``PYTHONHASHSEED`` environment variable is set before
         starting the Python interpreter to run this code. Not setting this may lead to
         reproducibility issues.
@@ -114,7 +118,6 @@ def train(
 
     env_config = env_config or {}
     rllib_config = rllib_config or {}
-    tune_config = tune_config or {}
     metrics = metrics or {}
 
     check_env_config(env_config)
@@ -172,18 +175,33 @@ def train(
 
     num_workers_ = (os.cpu_count() - 1) if num_workers is None else num_workers
 
+    timestr = datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
+    logdir_prefix = "{}_{}_{}".format(algorithm, env.__class__.__name__, timestr)
+
+    results_dir = os.path.expanduser(results_dir)
+
+    def logger_creator(config):
+        os.makedirs(results_dir, exist_ok=True)
+        logdir = tempfile.mkdtemp(prefix=logdir_prefix, dir=results_dir)
+        return ray.tune.logger.UnifiedLogger(config, logdir, loggers=None)
+
     config = {
+        "callbacks": RLlibMetricLogger(metrics),
+        "enable_connectors": True,
         "env": env_class.__name__,
         "env_config": env_config,
-        "num_sgd_iter": 10,
-        "num_workers": num_workers_,
-        "rollout_fragment_length": env.num_steps,
-        "train_batch_size": env.num_steps * max(1, num_workers_),
+        "framework": "torch",
+        "logger_creator": logger_creator,
         "multiagent": {
             "policies": policy_specs,
             "policy_mapping_fn": policy_mapping_fn,
             "policies_to_train": policies_to_train,
         },
+        "num_sgd_iter": 10,
+        "num_workers": num_workers_,
+        "rollout_fragment_length": env.num_steps,
+        "seed": 0,
+        "train_batch_size": env.num_steps * max(1, num_workers_),
     }
 
     config.update(rllib_config)
@@ -191,38 +209,50 @@ def train(
     if algorithm == "PPO":
         config["sgd_minibatch_size"] = max(int(config["train_batch_size"] / 10), 1)
 
-    if "callbacks" not in tune_config:
-        tune_config["callbacks"] = []
+    algo = ALGORITHMS[algorithm]()[0].get_default_config().from_dict(config).build()
 
-    tune_config["callbacks"].append(
-        RLlibTrainingStartCallback(
-            {
+    ray.init(ignore_reinit_error=True)
+
+    for i in rich.progress.track(range(iterations), description="Training..."):
+        result = algo.train()
+
+        if show_training_metrics:
+            rich.pretty.pprint(
+                {
+                    "iteration": i + 1,
+                    "metrics": result["custom_metrics"],
+                    "rewards": {
+                        "policy_reward_min": result["policy_reward_min"],
+                        "policy_reward_max": result["policy_reward_max"],
+                        "policy_reward_mean": result["policy_reward_mean"],
+                    },
+                }
+            )
+
+        if i == 0:
+            config = {
                 "algorithm": algorithm,
                 "env_class": env_class,
+                "iterations": iterations,
+                "checkpoint_freq": checkpoint_freq,
                 "policy_specs": policy_specs,
                 "policy_mapping": policy_mapping,
                 "policies_to_train": policies_to_train,
                 "env_config": env_config,
                 "rllib_config": rllib_config,
-                "tune_config": tune_config,
                 "metrics": metrics,
             }
-        )
-    )
 
-    if metrics is not None:
-        config["callbacks"] = RLlibMetricLogger(metrics)
+            cloudpickle.dump(
+                config, open(Path(algo.logdir, "phantom-training-params.pkl"), "wb")
+            )
 
-    try:
-        ray.init(local_mode=local_mode)
-        results = ray.tune.run(algorithm, config=config, **tune_config)
-    except Exception as exception:
-        # Ensure that Ray is properly shutdown in the instance of an error occuring
-        ray.shutdown()
-        raise exception
-    else:
-        ray.shutdown()
-        return results
+        if checkpoint_freq is not None and i % checkpoint_freq == 0:
+            algo.save()
+
+    print(f"Logs & checkpoints saved to: {algo.logdir}")
+
+    return algo
 
 
 class RLlibMetricLogger(DefaultCallbacks):
@@ -242,34 +272,12 @@ class RLlibMetricLogger(DefaultCallbacks):
         logging_helper(env, self.metrics, episode.user_data)
 
     def on_episode_end(self, *, episode, **kwargs) -> None:
-        for (metric_id, metric) in self.metrics.items():
+        for metric_id, metric in self.metrics.items():
             episode.custom_metrics[metric_id] = metric.reduce(
                 episode.user_data[metric_id], mode="train"
             )
 
     def __call__(self) -> "RLlibMetricLogger":
-        return self
-
-
-class RLlibTrainingStartCallback(LoggerCallback):
-    """Saves training parameters to the results directory at the start of training."""
-
-    def __init__(self, config: Dict[str, Any]) -> None:
-        super().__init__()
-        self.config = config
-
-    def on_trial_start(
-        self,
-        iteration: int,
-        trials: List[ray.tune.tune.Trial],
-        trial: ray.tune.tune.Trial,
-        **info: Any,
-    ) -> None:
-        cloudpickle.dump(
-            self.config, open(Path(trial.logdir, "phantom-training-params.pkl"), "wb")
-        )
-
-    def __call__(self) -> "RLlibTrainingStartCallback":
         return self
 
 

--- a/phantom/utils/rllib/train.py
+++ b/phantom/utils/rllib/train.py
@@ -22,7 +22,6 @@ import rich.pretty
 import rich.progress
 from ray import rllib
 from ray.rllib.algorithms import Algorithm
-from ray.rllib.algorithms.registry import ALGORITHMS
 from ray.rllib.algorithms.callbacks import DefaultCallbacks
 from ray.rllib.evaluation import Episode, MultiAgentEpisode
 from ray.rllib.policy.sample_batch import SampleBatch
@@ -176,7 +175,7 @@ def train(
     num_workers_ = (os.cpu_count() - 1) if num_workers is None else num_workers
 
     timestr = datetime.today().strftime("%Y-%m-%d_%H-%M-%S")
-    logdir_prefix = "{}_{}_{}".format(algorithm, env.__class__.__name__, timestr)
+    logdir_prefix = f"{algorithm}_{env.__class__.__name__}_{timestr}"
 
     results_dir = os.path.expanduser(results_dir)
 
@@ -248,9 +247,8 @@ def train(
                 "metrics": metrics,
             }
 
-            cloudpickle.dump(
-                config, open(Path(algo.logdir, "phantom-training-params.pkl"), "wb")
-            )
+            with open(Path(algo.logdir, "phantom-training-params.pkl"), "wb") as f:
+                cloudpickle.dump(config, f)
 
         if checkpoint_freq is not None and i % checkpoint_freq == 0:
             algo.save()

--- a/phantom/utils/rllib/train.py
+++ b/phantom/utils/rllib/train.py
@@ -210,6 +210,7 @@ def train(
     np.random.seed(config["seed"])
     if config["framework"] == "torch":
         import torch
+
         torch.manual_seed(config["seed"])
 
     if algorithm == "PPO":

--- a/phantom/utils/rllib/train.py
+++ b/phantom/utils/rllib/train.py
@@ -1,4 +1,5 @@
 import os
+import random
 import tempfile
 from datetime import datetime
 from inspect import isclass
@@ -204,6 +205,12 @@ def train(
     }
 
     config.update(rllib_config)
+
+    random.seed(config["seed"])
+    np.random.seed(config["seed"])
+    if config["framework"] == "torch":
+        import torch
+        torch.manual_seed(config["seed"])
 
     if algorithm == "PPO":
         config["sgd_minibatch_size"] = max(int(config["train_batch_size"] / 10), 1)

--- a/phantom/utils/rllib/train.py
+++ b/phantom/utils/rllib/train.py
@@ -116,11 +116,16 @@ def train(
     """
     show_pythonhashseed_warning()
 
+    assert iterations > 0, "'iterations' parameter must be > 0"
+    assert num_workers >= 0, "'num_workers' parameter must be >= 0"
+
     env_config = env_config or {}
     rllib_config = rllib_config or {}
     metrics = metrics or {}
 
     check_env_config(env_config)
+
+    ray.init(ignore_reinit_error=True)
 
     env = env_class(**env_config)
     env.reset()
@@ -198,20 +203,13 @@ def train(
             "policies_to_train": policies_to_train,
         },
         "num_sgd_iter": 10,
-        "num_workers": num_workers_,
+        "num_rollout_workers": num_workers_,
         "rollout_fragment_length": env.num_steps,
         "seed": 0,
         "train_batch_size": env.num_steps * max(1, num_workers_),
     }
 
     config.update(rllib_config)
-
-    random.seed(config["seed"])
-    np.random.seed(config["seed"])
-    if config["framework"] == "torch":
-        import torch
-
-        torch.manual_seed(config["seed"])
 
     if algorithm == "PPO":
         config["sgd_minibatch_size"] = max(int(config["train_batch_size"] / 10), 1)

--- a/phantom/utils/rllib/train.py
+++ b/phantom/utils/rllib/train.py
@@ -117,7 +117,9 @@ def train(
     show_pythonhashseed_warning()
 
     assert iterations > 0, "'iterations' parameter must be > 0"
-    assert num_workers >= 0, "'num_workers' parameter must be >= 0"
+
+    if num_workers is not None:
+        assert num_workers >= 0, "'num_workers' parameter must be >= 0"
 
     env_config = env_config or {}
     rllib_config = rllib_config or {}

--- a/phantom/utils/rllib/wrapper.py
+++ b/phantom/utils/rllib/wrapper.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Mapping
 import gym
 from ray import rllib
 
-from ...agents import AgentID, StrategicAgent
+from ...agents import AgentID
 from ...env import PhantomEnv
 
 

--- a/phantom/utils/rollout.py
+++ b/phantom/utils/rollout.py
@@ -17,7 +17,7 @@ from ..message import Message
 from ..types import AgentID, StageID
 
 
-@dataclass
+@dataclass(frozen=True)
 class AgentStep:
     """Describes a step taken by a single agent in an episode."""
 
@@ -30,7 +30,7 @@ class AgentStep:
     stage: Optional[StageID] = None
 
 
-@dataclass
+@dataclass(frozen=True)
 class Step:
     """Describes a step taken in an episode."""
 
@@ -44,22 +44,14 @@ class Step:
     stage: Optional[StageID] = None
 
 
+@dataclass(frozen=True)
 class Rollout:
-    def __init__(
-        self,
-        rollout_id: int,
-        repeat_id: int,
-        env_config: Mapping[str, Any],
-        rollout_params: Dict[str, Any],
-        steps: List[Step],
-        metrics: Dict[str, np.ndarray],
-    ) -> None:
-        self.rollout_id = rollout_id
-        self.repeat_id = repeat_id
-        self.env_config = env_config
-        self.rollout_params = rollout_params
-        self.steps = steps
-        self.metrics = metrics
+    rollout_id: int
+    repeat_id: int
+    env_config: Mapping[str, Any]
+    rollout_params: Dict[str, Any]
+    steps: List[Step]
+    metrics: Dict[str, np.ndarray]
 
     def observations_for_agent(
         self,

--- a/phantom/utils/rollout.py
+++ b/phantom/utils/rollout.py
@@ -11,6 +11,7 @@ from typing import (
 )
 
 import numpy as np
+import pandas as pd
 
 from ..message import Message
 from ..types import AgentID, StageID
@@ -238,3 +239,42 @@ class Rollout:
             return self.steps[index]
         except KeyError:
             KeyError(f"Index {index} not valid for trajectory")
+
+
+def rollouts_to_dataframe(
+    rollouts: Iterable[Rollout],
+    avg_over_repeats: bool = True,
+    index_value_precision: Optional[int] = None,
+) -> pd.DataFrame:
+    """
+    Converts a list of Rollouts into a MultiIndex DataFrame with rollout params as the
+    indexes and metrics as the columns.
+
+    Arguments:
+        rollouts: The list/iterator of Phantom Rollout objects to use.
+        avg_over_repeats: If True will average all metric values over each set of
+            repeats. This is very useful for reducing the overall data size if
+            individual rollouts are not required.
+        index_value_precision: If given will round the index values to the given
+            precision and convert to strings. This can be useful for avoiding floating
+            point inaccuracies when indexing (eg. 2.0 != 2.000000001).
+
+    Returns:
+        A Pandas DataFrame containing the results.
+    """
+
+    # Consume iterator (if applicable), throw away everything except params and metrics
+    rollouts = [(rollout.rollout_params, rollout.metrics) for rollout in rollouts]
+
+    index_cols = list(rollouts[0][0].keys())
+
+    df = pd.DataFrame([dict(**params, **metrics) for params, metrics in rollouts])
+
+    if index_value_precision is not None:
+        for col in index_cols:
+            df[col] = df[col].round(index_value_precision).astype(str)
+
+    if avg_over_repeats:
+        df = df.groupby(index_cols).mean().reset_index()
+
+    return df.set_index(index_cols)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
-black>=22.10.0
+black>=23.00.0
 flake8>=6.0.0
 # https://stackoverflow.com/questions/72191560/importerror-cannot-import-name-soft-unicode-from-markupsafe
 markupsafe==2.0.1
 mypy>=0.990
-pre-commit>=2.20.0
-pylint>=2.15.0
+pre-commit>=3.0.0
+pylint>=2.16.0
 pytest>=7.2.0
 pytest-cov>=4.0.0
 sphinx>=5.3.0
-sphinx-autodoc-typehints>=1.19.0
+sphinx-autodoc-typehints>=1.22
 sphinx_rtd_theme>=1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cloudpickle>=2.2.0
 # Temporary version fix due to RLlib issue:
-numpy<=1.24
+numpy<1.24
 ray[rllib]==2.2.0
 rich>=13.0
 tensorboardX>=2.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 cloudpickle>=2.2.0
+# Temporary version fix due to RLlib issue:
+numpy<=1.24
 ray[rllib]==2.2.0
 rich>=13.0
 tensorboardX>=2.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ rich>=13.0
 tensorboardX>=2.5.0
 torch>=1.13.0
 termcolor>=2.0.0
-tqdm>=4.64.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 cloudpickle>=2.2.0
-ray[rllib]==2.1.0
+ray[rllib]==2.2.0
+rich>=13.0
 tensorboardX>=2.5.0
-tensorflow>=2.10.0
-termcolor>=2.1.0
+torch>=1.13.0
+termcolor>=2.0.0
 tqdm>=4.64.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,7 @@ numpy<1.24
 ray[rllib]==2.2.0
 rich>=13.0
 tensorboardX>=2.5.0
+# Temporary include due to RLlib issue:
+tensorflow_probability>=0.19.0
 torch>=1.13.0
 termcolor>=2.0.0

--- a/scripts/view_telemetry.py
+++ b/scripts/view_telemetry.py
@@ -39,8 +39,10 @@ episode_num = st.sidebar.selectbox("Episode", list(range(1, len(episodes) + 1)))
 
 st.sidebar.subheader("Select Filters:")
 
+has_messages = episodes[0]["steps"][0]["messages"] is not None
+
 show_observations = st.sidebar.checkbox("Show Observations", True)
-show_messages = st.sidebar.checkbox("Show Messages", True)
+show_messages = st.sidebar.checkbox("Show Messages", True) if has_messages else False
 show_actions = st.sidebar.checkbox("Show Actions", True)
 show_rewards = st.sidebar.checkbox("Show Rewards", True)
 show_dones = st.sidebar.checkbox("Show Dones", False)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -30,8 +30,8 @@ class MockStrategicAgent(ph.StrategicAgent):
     def __init__(self, *args, num_steps: Optional[int] = None, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.action_space = gym.spaces.Discrete(2)
-        self.observation_space = gym.spaces.Discrete(2)
+        self.action_space = gym.spaces.Discrete(1)
+        self.observation_space = gym.spaces.Discrete(1)
 
         self.encode_obs_count = 0
         self.decode_action_count = 0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -30,8 +30,8 @@ class MockStrategicAgent(ph.StrategicAgent):
     def __init__(self, *args, num_steps: Optional[int] = None, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.action_space = gym.spaces.Discrete(1)
-        self.observation_space = gym.spaces.Discrete(1)
+        self.action_space = gym.spaces.Discrete(2)
+        self.observation_space = gym.spaces.Discrete(2)
 
         self.encode_obs_count = 0
         self.decode_action_count = 0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -41,7 +41,7 @@ class MockStrategicAgent(ph.StrategicAgent):
 
     def encode_observation(self, ctx: ph.Context):
         self.encode_obs_count += 1
-        return np.array([0])
+        return np.array([ctx.env_view.proportion_time_elapsed])
 
     def decode_action(self, ctx: ph.Context, action: np.ndarray):
         self.decode_action_count += 1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -30,8 +30,8 @@ class MockStrategicAgent(ph.StrategicAgent):
     def __init__(self, *args, num_steps: Optional[int] = None, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.action_space = gym.spaces.Discrete(1)
-        self.observation_space = gym.spaces.Discrete(1)
+        self.action_space = gym.spaces.Box(0, 1, (1,))
+        self.observation_space = gym.spaces.Box(0, 1, (1,))
 
         self.encode_obs_count = 0
         self.decode_action_count = 0
@@ -41,7 +41,7 @@ class MockStrategicAgent(ph.StrategicAgent):
 
     def encode_observation(self, ctx: ph.Context):
         self.encode_obs_count += 1
-        return 0
+        return np.array([0])
 
     def decode_action(self, ctx: ph.Context, action: np.ndarray):
         self.decode_action_count += 1

--- a/tests/fsm/test_odd_even_one_agent.py
+++ b/tests/fsm/test_odd_even_one_agent.py
@@ -48,7 +48,7 @@ def test_odd_even_one_agent():
     step = env.step({"agent": np.array([0])})
 
     assert env.current_stage == "EVEN"
-    assert step.observations == {"agent": np.array([0])}
+    assert step.observations == {"agent": np.array([1.0 / 3.0])}
     assert step.rewards == {"agent": 0.0}
     assert step.dones == {"__all__": False, "agent": False}
     assert step.infos == {"agent": {}}

--- a/tests/fsm/test_odd_even_two_agents.py
+++ b/tests/fsm/test_odd_even_two_agents.py
@@ -56,7 +56,7 @@ def test_odd_even_two_agents():
     step = env.step({"odd_agent": np.array([1])})
 
     assert env.current_stage == "EVEN"
-    assert step.observations == {"even_agent": np.array([0])}
+    assert step.observations == {"even_agent": np.array([1.0 / 3.0])}
     assert step.rewards == {"even_agent": None}
     assert step.dones == {"__all__": False, "even_agent": False, "odd_agent": False}
     assert step.infos == {"even_agent": {}}
@@ -72,7 +72,7 @@ def test_odd_even_two_agents():
     step = env.step({"even_agent": np.array([0])})
 
     assert env.current_stage == "ODD"
-    assert step.observations == {"odd_agent": np.array([0])}
+    assert step.observations == {"odd_agent": np.array([2.0 / 3.0])}
     assert step.rewards == {"odd_agent": 0.0}
     assert step.dones == {"__all__": False, "odd_agent": False, "even_agent": False}
     assert step.infos == {"odd_agent": {}}

--- a/tests/fsm/test_one_state.py
+++ b/tests/fsm/test_one_state.py
@@ -50,7 +50,7 @@ def test_one_state_with_handler():
     assert env.agents["agent"].encode_obs_count == 2
     assert env.agents["agent"].decode_action_count == 1
 
-    assert step.observations == {"agent": np.array([0.0])}
+    assert step.observations == {"agent": np.array([0.5])}
     assert step.rewards == {"agent": 0}
     assert step.dones == {"__all__": False, "agent": False}
     assert step.infos == {"agent": {}}
@@ -62,7 +62,7 @@ def test_one_state_with_handler():
     assert env.agents["agent"].encode_obs_count == 3
     assert env.agents["agent"].decode_action_count == 2
 
-    assert step.observations == {"agent": np.array([0.0])}
+    assert step.observations == {"agent": np.array([1.0])}
     assert step.rewards == {"agent": 0}
     assert step.dones == {"__all__": True, "agent": False}
     assert step.infos == {"agent": {}}
@@ -122,7 +122,7 @@ def test_one_state_without_handler():
     assert env.agents["agent"].encode_obs_count == 2
     assert env.agents["agent"].decode_action_count == 1
 
-    assert step.observations == {"agent": np.array([0.0])}
+    assert step.observations == {"agent": np.array([0.5])}
     assert step.rewards == {"agent": 0}
     assert step.dones == {"__all__": False, "agent": False}
     assert step.infos == {"agent": {}}
@@ -134,7 +134,7 @@ def test_one_state_without_handler():
     assert env.agents["agent"].encode_obs_count == 3
     assert env.agents["agent"].decode_action_count == 2
 
-    assert step.observations == {"agent": np.array([0.0])}
+    assert step.observations == {"agent": np.array([1.0])}
     assert step.rewards == {"agent": 0}
     assert step.dones == {"__all__": True, "agent": False}
     assert step.infos == {"agent": {}}

--- a/tests/utils/test_rllib.py
+++ b/tests/utils/test_rllib.py
@@ -1,4 +1,3 @@
-import numpy as np
 import phantom as ph
 import pytest
 
@@ -56,7 +55,7 @@ def test_rllib_train_rollout(tmpdir):
     # Evaluate policy:
     results = ph.utils.rllib.evaluate_policy(
         directory=f"{tmpdir}/LATEST",
-        obs=ph.utils.ranges.LinspaceRange(0, 1, 2, name="r", dtype=np.int),
+        obs=ph.utils.ranges.LinspaceRange(0, 1, 2, name="r", dtype=int),
         policy_id="mock_policy",
     )
     assert list(results) == [({"r": 0.0}, 0.0, 0), ({"r": 1.0}, 1.0, 0)]

--- a/tests/utils/test_rllib.py
+++ b/tests/utils/test_rllib.py
@@ -14,20 +14,16 @@ def test_rllib_train_rollout(tmpdir):
         },
         rllib_config={
             "disable_env_checking": True,
+            "num_rollout_workers": 1,
         },
-        tune_config={
-            "checkpoint_freq": 1,
-            "stop": {
-                "training_iteration": 2,
-            },
-            "local_dir": tmpdir,
-        },
-        num_workers=1,
+        iterations=2,
+        checkpoint_freq=1,
+        results_dir=tmpdir,
     )
 
     # Without workers, without env class:
     results = ph.utils.rllib.rollout(
-        directory=f"{tmpdir}/PPO/LATEST",
+        directory=f"{tmpdir}/LATEST",
         env_config={},
         num_repeats=3,
         num_workers=0,
@@ -36,7 +32,7 @@ def test_rllib_train_rollout(tmpdir):
 
     # With workers, with env class:
     results = ph.utils.rllib.rollout(
-        directory=f"{tmpdir}/PPO/LATEST",
+        directory=f"{tmpdir}/LATEST",
         env_class=MockEnv,
         env_config={},
         num_repeats=3,
@@ -47,7 +43,7 @@ def test_rllib_train_rollout(tmpdir):
     assert results[0].actions_for_agent("a1") == [0, 0, 0, 0, 0]
 
     results = ph.utils.rllib.rollout(
-        directory=f"{tmpdir}/PPO/LATEST",
+        directory=f"{tmpdir}/LATEST",
         env_class=MockEnv,
         env_config={},
         custom_policy_mapping={"a1": MockPolicy},
@@ -58,7 +54,7 @@ def test_rllib_train_rollout(tmpdir):
 
     # Evaluate policy:
     results = ph.utils.rllib.evaluate_policy(
-        directory=f"{tmpdir}/PPO/LATEST",
+        directory=f"{tmpdir}/LATEST",
         obs=0,
         policy_id="mock_policy",
     )

--- a/tests/utils/test_rllib.py
+++ b/tests/utils/test_rllib.py
@@ -43,6 +43,12 @@ def test_rllib_train_rollout(tmpdir):
     assert len(results) == 3
     assert results[0].actions_for_agent("a1") == [np.array([0.5])] * 5
 
+    # Data export:
+    ph.utils.rollout.rollouts_to_dataframe(results, avg_over_repeats=False)
+
+    with open(f"{tmpdir}/rollouts.json", "w") as f:
+        ph.utils.rollout.rollouts_to_jsonl(results, f)
+
     # With batched inference:
     results2 = ph.utils.rllib.rollout(
         directory=f"{tmpdir}/LATEST",

--- a/tests/utils/test_rllib.py
+++ b/tests/utils/test_rllib.py
@@ -41,7 +41,27 @@ def test_rllib_train_rollout(tmpdir):
     )
     results = list(results)
     assert len(results) == 3
-    assert results[0].actions_for_agent("a1") == [np.array([0.5])] * 5
+    assert np.array(results[0].actions_for_agent("a1")).flatten().tolist() == [
+        0.5021063685417175,
+        0.5272096991539001,
+        0.5454075932502747,
+        0.5570195913314819,
+        0.564277172088623,
+    ]
+    assert np.array(results[1].actions_for_agent("a1")).flatten().tolist() == [
+        0.5021063685417175,
+        0.5272096991539001,
+        0.5454075932502747,
+        0.5570195913314819,
+        0.564277172088623,
+    ]
+    assert np.array(results[2].actions_for_agent("a1")).flatten().tolist() == [
+        0.5021063685417175,
+        0.5272096991539001,
+        0.5454075932502747,
+        0.5570195913314819,
+        0.564277172088623,
+    ]
 
     # Data export:
     ph.utils.rollout.rollouts_to_dataframe(results, avg_over_repeats=False)
@@ -80,9 +100,9 @@ def test_rllib_train_rollout(tmpdir):
         explore=False,
     )
     assert list(results) == [
-        ({"r": 0.0}, [0.0], np.array([0.5], dtype=np.float32)),
-        ({"r": 0.5}, [0.5], np.array([0.49430978], dtype=np.float32)),
-        ({"r": 1.0}, [1.0], np.array([0.49243963], dtype=np.float32)),
+        ({"r": 0.0}, [0.0], np.array([0.50210637], dtype=np.float32)),
+        ({"r": 0.5}, [0.5], np.array([0.55189204], dtype=np.float32)),
+        ({"r": 1.0}, [1.0], np.array([0.56885237], dtype=np.float32)),
     ]
 
     # Evaluate policy (explore=True):
@@ -93,11 +113,11 @@ def test_rllib_train_rollout(tmpdir):
         explore=True,
     )
     assert list(results) == [
-        ({"r": 1.0}, [1.0], np.array([0.93560493], dtype=np.float32)),
-        ({"r": 1.0}, [1.0], np.array([0.0], dtype=np.float32)),
-        ({"r": 1.0}, [1.0], np.array([0.0], dtype=np.float32)),
-        ({"r": 1.0}, [1.0], np.array([0.17727578], dtype=np.float32)),
-        ({"r": 1.0}, [1.0], np.array([0.18336618], dtype=np.float32)),
+        ({"r": 1.0}, [1.0], np.array([0.34793535], dtype=np.float32)),
+        ({"r": 1.0}, [1.0], np.array([1.0], dtype=np.float32)),
+        ({"r": 1.0}, [1.0], np.array([1.0], dtype=np.float32)),
+        ({"r": 1.0}, [1.0], np.array([0.43988213], dtype=np.float32)),
+        ({"r": 1.0}, [1.0], np.array([1.0], dtype=np.float32)),
     ]
 
 

--- a/tests/utils/test_rllib.py
+++ b/tests/utils/test_rllib.py
@@ -41,27 +41,11 @@ def test_rllib_train_rollout(tmpdir):
     )
     results = list(results)
     assert len(results) == 3
-    assert np.array(results[0].actions_for_agent("a1")).flatten().tolist() == [
-        0.5021063685417175,
-        0.5272096991539001,
-        0.5454075932502747,
-        0.5570195913314819,
-        0.564277172088623,
-    ]
-    assert np.array(results[1].actions_for_agent("a1")).flatten().tolist() == [
-        0.5021063685417175,
-        0.5272096991539001,
-        0.5454075932502747,
-        0.5570195913314819,
-        0.564277172088623,
-    ]
-    assert np.array(results[2].actions_for_agent("a1")).flatten().tolist() == [
-        0.5021063685417175,
-        0.5272096991539001,
-        0.5454075932502747,
-        0.5570195913314819,
-        0.564277172088623,
-    ]
+    assert np.all(
+        results[0].actions_for_agent("a1")
+        == results[1].actions_for_agent("a1")
+        == results[2].actions_for_agent("a1")
+    )
 
     # Data export:
     ph.utils.rollout.rollouts_to_dataframe(results, avg_over_repeats=False)

--- a/tests/utils/test_rllib.py
+++ b/tests/utils/test_rllib.py
@@ -55,10 +55,10 @@ def test_rllib_train_rollout(tmpdir):
     # Evaluate policy:
     results = ph.utils.rllib.evaluate_policy(
         directory=f"{tmpdir}/LATEST",
-        obs=ph.utils.ranges.LinspaceRange(0, 1, 2, name="r", dtype=int),
+        obs=ph.utils.ranges.LinspaceRange(0, 0, 1, name="r", dtype=int),
         policy_id="mock_policy",
     )
-    assert list(results) == [({"r": 0.0}, 0.0, 0), ({"r": 1.0}, 1.0, 0)]
+    assert list(results) == [({"r": 0.0}, 0.0, 0)]
 
 
 def test_rllib_rollout_bad(tmpdir):

--- a/tests/utils/test_rllib.py
+++ b/tests/utils/test_rllib.py
@@ -58,7 +58,7 @@ def test_rllib_train_rollout(tmpdir):
         obs=0,
         policy_id="mock_policy",
     )
-    assert len(list(results)) == 1
+    assert list(results) == [({}, 0)]
 
 
 def test_rllib_rollout_bad(tmpdir):

--- a/tests/utils/test_rllib.py
+++ b/tests/utils/test_rllib.py
@@ -55,10 +55,10 @@ def test_rllib_train_rollout(tmpdir):
     # Evaluate policy:
     results = ph.utils.rllib.evaluate_policy(
         directory=f"{tmpdir}/LATEST",
-        obs=0,
+        obs=ph.utils.ranges.LinspaceRange(0, 1, 2, name="r"),
         policy_id="mock_policy",
     )
-    assert list(results) == [({}, 0)]
+    assert list(results) == [({"r": 0.0}, 0.0, 0), ({"r": 1.0}, 1.0, 0)]
 
 
 def test_rllib_rollout_bad(tmpdir):

--- a/tests/utils/test_rllib.py
+++ b/tests/utils/test_rllib.py
@@ -83,26 +83,30 @@ def test_rllib_train_rollout(tmpdir):
         policy_id="mock_policy",
         explore=False,
     )
-    assert list(results) == [
-        ({"r": 0.0}, [0.0], np.array([0.50210637], dtype=np.float32)),
-        ({"r": 0.5}, [0.5], np.array([0.55189204], dtype=np.float32)),
-        ({"r": 1.0}, [1.0], np.array([0.56885237], dtype=np.float32)),
-    ]
+    results = list(results)
+
+    assert results[0][0] == {"r": 0.0}
+    assert results[1][0] == {"r": 0.5}
+    assert results[2][0] == {"r": 1.0}
+    assert results[0][1][0] == 0.0
+    assert results[1][1][0] == 0.5
+    assert results[2][1][0] == 1.0
 
     # Evaluate policy (explore=True):
     results = ph.utils.rllib.evaluate_policy(
         directory=f"{tmpdir}/LATEST",
-        obs=[ph.utils.ranges.LinspaceRange(1.0, 1.0, 5, name="r")],
+        obs=[ph.utils.ranges.LinspaceRange(0.0, 1.0, 3, name="r")],
         policy_id="mock_policy",
         explore=True,
     )
-    assert list(results) == [
-        ({"r": 1.0}, [1.0], np.array([0.34793535], dtype=np.float32)),
-        ({"r": 1.0}, [1.0], np.array([1.0], dtype=np.float32)),
-        ({"r": 1.0}, [1.0], np.array([1.0], dtype=np.float32)),
-        ({"r": 1.0}, [1.0], np.array([0.43988213], dtype=np.float32)),
-        ({"r": 1.0}, [1.0], np.array([1.0], dtype=np.float32)),
-    ]
+    results = list(results)
+
+    assert results[0][0] == {"r": 0.0}
+    assert results[1][0] == {"r": 0.5}
+    assert results[2][0] == {"r": 1.0}
+    assert results[0][1][0] == 0.0
+    assert results[1][1][0] == 0.5
+    assert results[2][1][0] == 1.0
 
 
 def test_rllib_rollout_bad(tmpdir):

--- a/tests/utils/test_rllib.py
+++ b/tests/utils/test_rllib.py
@@ -1,3 +1,4 @@
+import numpy as np
 import phantom as ph
 import pytest
 
@@ -55,7 +56,7 @@ def test_rllib_train_rollout(tmpdir):
     # Evaluate policy:
     results = ph.utils.rllib.evaluate_policy(
         directory=f"{tmpdir}/LATEST",
-        obs=ph.utils.ranges.LinspaceRange(0, 1, 2, name="r"),
+        obs=ph.utils.ranges.LinspaceRange(0, 1, 2, name="r", dtype=np.int),
         policy_id="mock_policy",
     )
     assert list(results) == [({"r": 0.0}, 0.0, 0), ({"r": 1.0}, 1.0, 0)]


### PR DESCRIPTION
Done:

- [x] Replace Ray tune with own training loop
- [x] Update to use newer Ray/RLlib APIs
- [x] Switch default RLlib training framework from tensorflow to PyTorch
- [x] Enable RLlib connectors
- [x] Swap tqdm for rich for progress bars
- [x] Use RLlib Policy objects instead of Algorithm objects for rollouts
- [x] Implement vectorised rollouts

Unscientific performance measurements:

```
Supply Chain, 0 workers, 10 rollouts:

Base            : 15s
Policy          : 5s
Vectorised(1)   : 5s
Vectorised(10)  : 4s


Supply Chain, 0 workers, 100 rollouts:

Base            : 22s
Policy          : 11s
Vectorised(1)   : 11s
Vectorised(10)  : 6s
Vectorised(100) : 5s


Supply Chain, 0 workers, 1000 rollouts:

Base            : 103s
Policy          : 82s
Vectorised(1)   : 83s
Vectorised(10)  : 29s
Vectorised(100) : 22s
```